### PR TITLE
Update wandb logging to group runs by dataset

### DIFF
--- a/src/lib/loggers.py
+++ b/src/lib/loggers.py
@@ -79,10 +79,10 @@ class WeightsAndBiasesLogger(LightningLoggerBase):
         super(WeightsAndBiasesLogger, self).__init__()
 
         run_info = get_default_run_info(name, tag, run, cfg)
-        self.group = run_info.group
+        self.group = cfg.dataset_config.name  # Group runs by dataset name
         self.wanbd_run = wandb.init(
             project=WANDB_PROJECT,
-            group=run_info.group,
+            group=self.group,
             name=run_info.name,
             id=run_info.id,
             dir=run_info.dir,

--- a/src/lib/wandb_utils.py
+++ b/src/lib/wandb_utils.py
@@ -40,8 +40,8 @@ def get_default_run_info(experiment_name, tag, run, cfg):
     if isinstance(run, int):
         run = f"run-{run}"
 
-    group = f"{experiment_name}-{tag}"
-    name = f"{group}-{run}"
+    group = cfg["dataset_config"]["name"]  # Group runs by dataset name
+    name = f"{experiment_name}-{tag}-{run}"
     _dir = helpers.get_save_dir(experiment_name, tag, run)
     os.makedirs(_dir, exist_ok=True)
 


### PR DESCRIPTION
Modify the `WeightsAndBiasesLogger` class to group runs by dataset name instead of method-dataset combination.

* **src/lib/loggers.py**
  - Set the `group` parameter to the dataset name in the `WeightsAndBiasesLogger` class.

* **src/lib/wandb_utils.py**
  - Update the `get_default_run_info` function to include the dataset name in the group identifier.

