### PR TITLE
Add file structure description to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,3 +150,24 @@ The custom experiment can then be run with
 ```bash
 python train.py -c noisymnist_comvc_custom
 ```
+
+## Project File Structure
+
+This section provides an overview of the main directories and files in the project, along with their purpose and functionality.
+
+- `.dockerignore`: Specifies files and directories to be ignored by Docker.
+- `.gitignore`: Specifies files and directories to be ignored by Git.
+- `environment.yml`: Defines the conda environment and its dependencies.
+- `LICENSE`: Contains the license information for the project.
+- `README.md`: Provides an overview of the project, including instructions and documentation.
+- `requirements.txt`: Lists the Python dependencies required for the project.
+- `src/config`: Contains configuration files and templates for experiments, datasets, models, etc.
+- `src/data`: Contains scripts and modules for data loading, preprocessing, and augmentation.
+- `src/helpers.py`: Contains helper functions used throughout the project.
+- `src/lib`: Contains utility modules and functions for evaluation, logging, loss computation, etc.
+- `src/models`: Contains the implementation of various models used in the project.
+- `src/register.py`: Contains the registration of custom modules and functions.
+- `src/train.py`: Contains the main training script for running experiments.
+
+For detailed descriptions of the files in each directory, please refer to the respective `README.md` files in the corresponding directories.
+

--- a/src/README.md
+++ b/src/README.md
@@ -1,0 +1,42 @@
+# Source Directory
+
+This directory contains the main source code for the project. Below is a brief description of each subdirectory and its purpose.
+
+## Subdirectories
+
+- `config`: Contains configuration files and templates for experiments, datasets, models, etc.
+- `data`: Contains scripts and modules for data loading, preprocessing, and augmentation.
+- `lib`: Contains utility modules and functions for evaluation, logging, loss computation, etc.
+- `models`: Contains the implementation of various models used in the project.
+
+For detailed descriptions of the files in each subdirectory, please refer to the respective `README.md` files in the corresponding directories.
+
+## Toggle Chinese Translation
+
+<button onclick="toggleTranslation()">Toggle Chinese Translation</button>
+
+<script>
+function toggleTranslation() {
+  var x = document.getElementById("chinese-translation");
+  if (x.style.display === "none") {
+    x.style.display = "block";
+  } else {
+    x.style.display = "none";
+  }
+}
+</script>
+
+<div id="chinese-translation" style="display:none;">
+  <h1>源目录</h1>
+  <p>此目录包含项目的主要源代码。以下是每个子目录及其用途的简要说明。</p>
+
+  <h2>子目录</h2>
+  <ul>
+    <li><code>config</code>：包含实验、数据集、模型等的配置文件和模板。</li>
+    <li><code>data</code>：包含数据加载、预处理和增强的脚本和模块。</li>
+    <li><code>lib</code>：包含用于评估、日志记录、损失计算等的实用程序模块和函数。</li>
+    <li><code>models</code>：包含项目中使用的各种模型的实现。</li>
+  </ul>
+
+  <p>有关每个子目录中文件的详细说明，请参阅相应目录中的<code>README.md</code>文件。</p>
+</div>

--- a/src/config/README.md
+++ b/src/config/README.md
@@ -1,0 +1,53 @@
+# src/config Directory
+
+This directory contains configuration files and templates for experiments, datasets, models, and other components of the project.
+
+## Files
+
+- `__init__.py`: Initializes the `config` module and provides utility functions for parsing and updating configurations.
+- `config.py`: Defines the base `Config` class used for creating hierarchical configuration objects.
+- `constants.py`: Contains constant values used throughout the project, such as directory paths and device settings.
+- `experiments`: Directory containing experiment configurations and templates.
+  - `__init__.py`: Initializes the `experiments` module and imports experiment configurations.
+  - `ablation`: Directory containing ablation study configurations.
+    - `__init__.py`: Initializes the `ablation` module and imports ablation study configurations.
+    - `fusion.py`: Defines ablation study configurations for fusion methods.
+    - `mv_ssl.py`: Defines ablation study configurations for multi-view self-supervised learning.
+    - `sv_ssl.py`: Defines ablation study configurations for single-view self-supervised learning.
+  - `base_experiments.py`: Defines base experiment configurations for various datasets.
+  - `benchmark`: Directory containing benchmark experiment configurations.
+    - `__init__.py`: Initializes the `benchmark` module and imports benchmark experiment configurations.
+    - `comvc.py`: Defines benchmark experiment configurations for the CoMVC model.
+    - `contrastive_ae.py`: Defines benchmark experiment configurations for the Contrastive Autoencoder model.
+    - `dmsc.py`: Defines benchmark experiment configurations for the DMSC model.
+    - `eamc.py`: Defines benchmark experiment configurations for the EAMC model.
+    - `mimvc.py`: Defines benchmark experiment configurations for the MIMVC model.
+    - `mvae.py`: Defines benchmark experiment configurations for the MVAE model.
+    - `mviic.py`: Defines benchmark experiment configurations for the MvIIC model.
+    - `mvscn.py`: Defines benchmark experiment configurations for the MvSCN model.
+    - `simvc.py`: Defines benchmark experiment configurations for the SiMVC model.
+  - `increasing_n_views`: Directory containing experiment configurations for increasing the number of views.
+    - `__init__.py`: Initializes the `increasing_n_views` module and imports experiment configurations.
+    - `caltech7.py`: Defines experiment configurations for increasing the number of views on the Caltech7 dataset.
+    - `patchedmnist.py`: Defines experiment configurations for increasing the number of views on the PatchedMNIST dataset.
+- `templates`: Directory containing configuration templates for various components.
+  - `__init__.py`: Initializes the `templates` module and imports configuration templates.
+  - `augmenter.py`: Defines configuration templates for data augmentation.
+  - `clustering_module.py`: Defines configuration templates for clustering modules.
+  - `dataset.py`: Defines configuration templates for datasets.
+  - `encoder.py`: Defines configuration templates for encoders.
+  - `experiment.py`: Defines the base `Experiment` class used for creating experiment configurations.
+  - `fusion.py`: Defines configuration templates for fusion methods.
+  - `kernel_width.py`: Defines configuration templates for kernel width estimation methods.
+  - `layers.py`: Defines configuration templates for neural network layers.
+  - `models`: Directory containing configuration templates for models.
+    - `__init__.py`: Initializes the `models` module and imports model configuration templates.
+    - `custom.py`: Defines custom model configuration templates.
+    - `dmsc.py`: Defines configuration templates for the DMSC model.
+    - `eamc.py`: Defines configuration templates for the EAMC model.
+    - `mimvc.py`: Defines configuration templates for the MIMVC model.
+    - `mvae.py`: Defines configuration templates for the MVAE model.
+    - `mviic.py`: Defines configuration templates for the MvIIC model.
+    - `mvscn.py`: Defines configuration templates for the MvSCN model.
+    - `simvc_comvc.py`: Defines configuration templates for the SiMVC and CoMVC models.
+  - `optimizer.py`: Defines configuration templates for optimizers.

--- a/src/data/README.md
+++ b/src/data/README.md
@@ -1,0 +1,45 @@
+# src/data Directory
+
+This directory contains scripts and modules for data loading, preprocessing, and augmentation.
+
+## Files
+
+- `__init__.py`: Initializes the data module.
+- `augmenter.py`: Contains data augmentation functions and classes.
+- `data_module.py`: Defines the data module for loading and processing datasets.
+- `load.py`: Contains functions for loading datasets.
+- `make_dataset.py`: Contains scripts for generating datasets.
+- `pair_dataset.py`: Contains scripts for generating paired datasets for pre-training.
+- `torchvision_datasets.py`: Contains functions for loading datasets from the torchvision library.
+
+## Toggle Chinese Translation
+
+<button onclick="toggleTranslation()">Toggle Chinese Translation</button>
+
+<script>
+function toggleTranslation() {
+  var elements = document.getElementsByClassName('chinese-translation');
+  for (var i = 0; i < elements.length; i++) {
+    if (elements[i].style.display === 'none') {
+      elements[i].style.display = 'block';
+    } else {
+      elements[i].style.display = 'none';
+    }
+  }
+}
+</script>
+
+<div class="chinese-translation" style="display:none;">
+  <h1>src/data 目录</h1>
+  <p>此目录包含用于数据加载、预处理和增强的脚本和模块。</p>
+  <h2>文件</h2>
+  <ul>
+    <li><code>__init__.py</code>：初始化数据模块。</li>
+    <li><code>augmenter.py</code>：包含数据增强函数和类。</li>
+    <li><code>data_module.py</code>：定义用于加载和处理数据集的数据模块。</li>
+    <li><code>load.py</code>：包含加载数据集的函数。</li>
+    <li><code>make_dataset.py</code>：包含生成数据集的脚本。</li>
+    <li><code>pair_dataset.py</code>：包含生成用于预训练的配对数据集的脚本。</li>
+    <li><code>torchvision_datasets.py</code>：包含从 torchvision 库加载数据集的函数。</li>
+  </ul>
+</div>

--- a/src/lib/README.md
+++ b/src/lib/README.md
@@ -1,0 +1,62 @@
+# src/lib Directory
+
+This directory contains utility modules and functions for evaluation, logging, loss computation, and other tasks.
+
+## Files
+
+- `encoder.py`: Contains the implementation of the encoder network used in the project.
+- `evaluate.py`: Contains functions for evaluating the performance of the models.
+- `fusion.py`: Contains the implementation of fusion modules used to combine multiple views.
+- `kernel.py`: Contains functions for computing kernel matrices.
+- `loggers.py`: Contains custom loggers for logging experiment results.
+- `loss/__init__.py`: Contains the initialization file for the loss module.
+- `loss/loss.py`: Contains the implementation of various loss functions used in the project.
+- `loss/terms.py`: Contains the implementation of individual loss terms.
+- `loss/utils.py`: Contains utility functions for loss computation.
+- `metrics.py`: Contains functions for computing evaluation metrics.
+- `normalization.py`: Contains functions for normalizing data.
+- `projector.py`: Contains the implementation of the projector network used in the project.
+- `wandb_utils.py`: Contains utility functions for logging experiment results with Weights and Biases.
+
+For detailed descriptions of the files in this directory, please refer to the respective files.
+
+## Toggle Chinese Translation
+
+<button onclick="toggleTranslation()">Toggle Chinese Translation</button>
+
+<script>
+function toggleTranslation() {
+  var elements = document.getElementsByClassName('chinese-translation');
+  for (var i = 0; i < elements.length; i++) {
+    if (elements[i].style.display === 'none') {
+      elements[i].style.display = 'block';
+    } else {
+      elements[i].style.display = 'none';
+    }
+  }
+}
+</script>
+
+<div class="chinese-translation" style="display:none;">
+  <h1>src/lib 目录</h1>
+
+  该目录包含用于评估、日志记录、损失计算和其他任务的实用程序模块和函数。
+
+  ## 文件
+
+  - `encoder.py`：包含项目中使用的编码器网络的实现。
+  - `evaluate.py`：包含用于评估模型性能的函数。
+  - `fusion.py`：包含用于组合多个视图的融合模块的实现。
+  - `kernel.py`：包含计算核矩阵的函数。
+  - `loggers.py`：包含用于记录实验结果的自定义记录器。
+  - `loss/__init__.py`：包含损失模块的初始化文件。
+  - `loss/loss.py`：包含项目中使用的各种损失函数的实现。
+  - `loss/terms.py`：包含各个损失项的实现。
+  - `loss/utils.py`：包含损失计算的实用函数。
+  - `metrics.py`：包含计算评估指标的函数。
+  - `normalization.py`：包含用于数据归一化的函数。
+  - `projector.py`：包含项目中使用的投影器网络的实现。
+  - `wandb_utils.py`：包含用于记录实验结果的实用函数。
+
+  有关此目录中各个文件的详细描述，请参阅相应的文件。
+</div>

--- a/src/models/README.md
+++ b/src/models/README.md
@@ -1,0 +1,54 @@
+# Models Directory
+
+This directory contains the implementation of various models used in the project. Each model is implemented in its own subdirectory, and the corresponding loss functions are also included.
+
+## Subdirectories and Files
+
+- `comvc`: Contains the implementation of the CoMVC model and its loss functions.
+- `contrastive_ae`: Contains the implementation of the Contrastive Autoencoder model.
+- `dmsc`: Contains the implementation of the DMSC model and its loss functions.
+- `eamc`: Contains the implementation of the EAMC model and its loss functions.
+- `mimvc`: Contains the implementation of the MIMVC model and its loss functions.
+- `mvae`: Contains the implementation of the MVAE model and its loss functions.
+- `mviic`: Contains the implementation of the MvIIC model and its loss functions.
+- `mvscn`: Contains the implementation of the MVSCN model and its loss functions.
+- `simvc`: Contains the implementation of the SiMVC model.
+
+For detailed descriptions of the files in each subdirectory, please refer to the respective `README.md` files in the corresponding subdirectories.
+
+## Toggle Chinese Translation
+
+To view the Chinese translation of this document, click the button below:
+
+<button onclick="toggleTranslation()">Toggle Chinese Translation</button>
+
+<script>
+function toggleTranslation() {
+  var x = document.getElementById("chinese-translation");
+  if (x.style.display === "none") {
+    x.style.display = "block";
+  } else {
+    x.style.display = "none";
+  }
+}
+</script>
+
+<div id="chinese-translation" style="display:none;">
+  <h1>模型目录</h1>
+  <p>此目录包含项目中使用的各种模型的实现。每个模型都在其自己的子目录中实现，并且还包括相应的损失函数。</p>
+
+  <h2>子目录和文件</h2>
+  <ul>
+    <li><code>comvc</code>：包含CoMVC模型及其损失函数的实现。</li>
+    <li><code>contrastive_ae</code>：包含对比自编码器模型的实现。</li>
+    <li><code>dmsc</code>：包含DMSC模型及其损失函数的实现。</li>
+    <li><code>eamc</code>：包含EAMC模型及其损失函数的实现。</li>
+    <li><code>mimvc</code>：包含MIMVC模型及其损失函数的实现。</li>
+    <li><code>mvae</code>：包含MVAE模型及其损失函数的实现。</li>
+    <li><code>mviic</code>：包含MvIIC模型及其损失函数的实现。</li>
+    <li><code>mvscn</code>：包含MVSCN模型及其损失函数的实现。</li>
+    <li><code>simvc</code>：包含SiMVC模型的实现。</li>
+  </ul>
+
+  <p>有关每个子目录中文件的详细描述，请参阅相应子目录中的<code>README.md</code>文件。</p>
+</div>


### PR DESCRIPTION
Add project file structure descriptions to README files.

* **Main README.md**: Add a new section "## Project File Structure" with brief descriptions of the main directories and files in the project.
* **src/config/README.md**: Add a new README file describing the purpose and functionality of the `src/config` directory and its files.
* **src/data/README.md**: Add a new README file describing the purpose and functionality of the `src/data` directory and its files.
* **src/lib/README.md**: Add a new README file describing the purpose and functionality of the `src/lib` directory and its files.
* **src/models/README.md**: Add a new README file describing the purpose and functionality of the `src/models` directory and its files.
* **src/README.md**: Add a new README file describing the purpose and functionality of the `src` directory and its subdirectories.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/liu2048/DeepMVC/pull/4?shareId=60397d47-0106-458d-9d52-d17ae5182793).