### PR TITLE
Add scripts for benchmark, ablation, and increasing views experiments

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ This section provides an overview of the main directories and files in the proje
 - `src/models`: Contains the implementation of various models used in the project.
 - `src/register.py`: Contains the registration of custom modules and functions.
 - `src/train.py`: Contains the main training script for running experiments.
+- `src/scripts`: Contains shell scripts for running experiments and generating datasets.
+  - `generate_datasets.sh`: Generates datasets for the project.
+  - `benchmark.sh`: Runs benchmark experiments for the project.
+  - `ablation.sh`: Runs ablation study experiments for the project.
+  - `increasing_views.sh`: Runs experiments with increasing views for the project.
 
 For detailed descriptions of the files in each directory, please refer to the respective `README.md` files in the corresponding directories.
-

--- a/src/scripts/ablation.sh
+++ b/src/scripts/ablation.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+# This script runs ablation study experiments for the project.
+# Usage: ./ablation.sh
+
+# Navigate to the src directory
+cd "$(dirname "$0")/.."
+
+# Run ablation study experiments for fusion methods on NoisyMNIST dataset
+python train.py -c ablfusion_noisymnist_eamc
+python train.py -c ablfusion_noisymnist_simvc
+python train.py -c ablfusion_noisymnist_comvc
+python train.py -c ablfusion_noisymnist_sae
+python train.py -c ablfusion_noisymnist_cae
+
+# Run ablation study experiments for fusion methods on Caltech7 dataset
+python train.py -c ablfusion_caltech7_eamc
+python train.py -c ablfusion_caltech7_simvc
+python train.py -c ablfusion_caltech7_comvc
+python train.py -c ablfusion_caltech7_sae
+python train.py -c ablfusion_caltech7_cae
+
+# Run ablation study experiments for MV-SSL methods on NoisyMNIST dataset
+python train.py -c ablmvssl_noisymnist_eamc
+python train.py -c ablmvssl_caltech7_eamc
+python train.py -c ablmvssl_noisymnist_mvscn
+python train.py -c ablmvssl_caltech7_mvscn
+python train.py -c ablmvssl_noisymnist_mvae
+python train.py -c ablmvssl_caltech7_mvae
+python train.py -c ablmvssl_noisymnist_mviic
+python train.py -c ablmvssl_caltech7_mviic
+
+# Run ablation study experiments for SV-SSL methods on NoisyMNIST dataset
+python train.py -c ablsvssl_noisymnist_mvscn
+python train.py -c ablsvssl_noisymnist_caekm
+python train.py -c ablsvssl_noisymnist_saekm
+python train.py -c ablsvssl_caltech7_mvscn
+python train.py -c ablsvssl_caltech7_caekm
+python train.py -c ablsvssl_caltech7_saekm
+python train.py -c ablsvssl_noisymnist_dmsc
+python train.py -c ablsvssl_caltech7_dmsc

--- a/src/scripts/benchmark.sh
+++ b/src/scripts/benchmark.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+
+# This script runs benchmark experiments for the project.
+# Usage: ./benchmark.sh
+
+# Navigate to the src directory
+cd "$(dirname "$0")/.."
+
+# Run benchmark experiments for CoMVC model across different datasets
+python train.py -c blobs_comvc
+python train.py -c noisymnist_comvc
+python train.py -c edgemnist_comvc
+python train.py -c caltech20_comvc
+python train.py -c caltech7_comvc
+python train.py -c noisyfashionmnist_comvc
+python train.py -c edgefashionmnist_comvc
+python train.py -c coil20_comvc
+python train.py -c patchedmnist_comvc
+
+# Run benchmark experiments for CAE model across different datasets
+python train.py -c noisymnist_cae
+python train.py -c edgemnist_cae
+python train.py -c caltech20_cae
+python train.py -c caltech7_cae
+python train.py -c noisyfashionmnist_cae
+python train.py -c edgefashionmnist_cae
+python train.py -c coil20_cae
+python train.py -c patchedmnist_cae
+
+# Run benchmark experiments for CAEKM model across different datasets
+python train.py -c noisymnist_caekm
+python train.py -c edgemnist_caekm
+python train.py -c caltech20_caekm
+python train.py -c caltech7_caekm
+python train.py -c noisyfashionmnist_caekm
+python train.py -c edgefashionmnist_caekm
+python train.py -c coil20_caekm
+python train.py -c patchedmnist_caekm
+
+# Run benchmark experiments for SAE model across different datasets
+python train.py -c noisymnist_sae
+python train.py -c edgemnist_sae
+python train.py -c caltech20_sae
+python train.py -c caltech7_sae
+python train.py -c noisyfashionmnist_sae
+python train.py -c edgefashionmnist_sae
+python train.py -c coil20_sae
+python train.py -c patchedmnist_sae
+
+# Run benchmark experiments for SAEKM model across different datasets
+python train.py -c noisymnist_saekm
+python train.py -c edgemnist_saekm
+python train.py -c caltech20_saekm
+python train.py -c caltech7_saekm
+python train.py -c noisyfashionmnist_saekm
+python train.py -c edgefashionmnist_saekm
+python train.py -c coil20_saekm
+python train.py -c patchedmnist_saekm
+
+# Run benchmark experiments for DMSC model across different datasets
+python train.py -c blobs_dmsc
+python train.py -c noisymnist_dmsc
+python train.py -c edgemnist_dmsc
+python train.py -c noisyfashionmnist_dmsc
+python train.py -c edgefashionmnist_dmsc
+python train.py -c caltech20_dmsc
+python train.py -c caltech7_dmsc
+python train.py -c coil20_dmsc
+python train.py -c patchedmnist_dmsc
+
+# Run benchmark experiments for EAMC model across different datasets
+python train.py -c blobs_eamc
+python train.py -c noisymnist_eamc
+python train.py -c edgemnist_eamc
+python train.py -c caltech20_eamc
+python train.py -c caltech7_eamc
+python train.py -c noisyfashionmnist_eamc
+python train.py -c edgefashionmnist_eamc
+python train.py -c coil20_eamc
+python train.py -c patchedmnist_eamc
+
+# Run benchmark experiments for MIMVC model across different datasets
+python train.py -c blobs_mimvc
+python train.py -c noisymnist_mimvc
+python train.py -c edgemnist_mimvc
+python train.py -c caltech20_mimvc
+python train.py -c caltech7_mimvc
+python train.py -c noisyfashionmnist_mimvc
+python train.py -c edgefashionmnist_mimvc
+python train.py -c coil20_mimvc
+python train.py -c patchedmnist_mimvc
+
+# Run benchmark experiments for MultiVAE model across different datasets
+python train.py -c blobs_mvae
+python train.py -c noisymnist_mvae
+python train.py -c edgemnist_mvae
+python train.py -c caltech20_mvae
+python train.py -c caltech7_mvae
+python train.py -c noisyfashionmnist_mvae
+python train.py -c edgefashionmnist_mvae
+python train.py -c coil20_mvae
+python train.py -c patchedmnist_mvae
+
+# Run benchmark experiments for MvIIC model across different datasets
+python train.py -c blobs_mviic
+python train.py -c noisymnist_mviic
+python train.py -c edgemnist_mviic
+python train.py -c caltech20_mviic
+python train.py -c caltech7_mviic
+python train.py -c noisyfashionmnist_mviic
+python train.py -c edgefashionmnist_mviic
+python train.py -c coil20_mviic
+python train.py -c patchedmnist_mviic
+
+# Run benchmark experiments for MVSCN model across different datasets
+python train.py -c blobs_mvscn
+python train.py -c noisymnist_mvscn
+python train.py -c noisyfashionmnist_mvscn
+python train.py -c edgemnist_mvscn
+python train.py -c edgefashionmnist_mvscn
+python train.py -c coil20_mvscn
+python train.py -c caltech20_mvscn
+python train.py -c caltech7_mvscn
+python train.py -c patchedmnist_mvscn
+
+# Run benchmark experiments for SiMVC model across different datasets
+python train.py -c blobs_simvc
+python train.py -c noisymnist_simvc
+python train.py -c noisyfashionmnist_simvc
+python train.py -c edgemnist_simvc
+python train.py -c edgefashionmnist_simvc
+python train.py -c coil20_simvc
+python train.py -c caltech20_simvc
+python train.py -c caltech7_simvc
+python train.py -c patchedmnist_simvc

--- a/src/scripts/generate_datasets.sh
+++ b/src/scripts/generate_datasets.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# This script generates datasets for the project.
+# Usage: ./generate_datasets.sh
+
+# Navigate to the src directory
+cd "$(dirname "$0")/.."
+
+# Generate datasets
+python -m data.make_dataset noisymnist noisyfashionmnist edgemnist edgefashionmnist patchedmnist
+python -m data.make_dataset caltech20 caltech7 coil20

--- a/src/scripts/increasing_views.sh
+++ b/src/scripts/increasing_views.sh
@@ -1,0 +1,303 @@
+#!/bin/bash
+
+# This script runs experiments with increasing views for the project.
+# Usage: ./increasing_views.sh
+
+# Navigate to the src directory
+cd "$(dirname "$0")/.."
+
+# Run experiments with increasing views for Caltech7 dataset
+# SiMVC model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_caltech7_simvc
+python train.py -c incviews3wb_caltech7_simvc
+python train.py -c incviews4wb_caltech7_simvc
+python train.py -c incviews5wb_caltech7_simvc
+python train.py -c incviews6wb_caltech7_simvc
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_caltech7_simvc
+python train.py -c incviews3bw_caltech7_simvc
+python train.py -c incviews4bw_caltech7_simvc
+python train.py -c incviews5bw_caltech7_simvc
+python train.py -c incviews6bw_caltech7_simvc
+
+# CoMVC model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_caltech7_comvc
+python train.py -c incviews3wb_caltech7_comvc
+python train.py -c incviews4wb_caltech7_comvc
+python train.py -c incviews5wb_caltech7_comvc
+python train.py -c incviews6wb_caltech7_comvc
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_caltech7_comvc
+python train.py -c incviews3bw_caltech7_comvc
+python train.py -c incviews4bw_caltech7_comvc
+python train.py -c incviews5bw_caltech7_comvc
+python train.py -c incviews6bw_caltech7_comvc
+
+# CoMVC without adaptive weight model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_caltech7_comvcnoad
+python train.py -c incviews3wb_caltech7_comvcnoad
+python train.py -c incviews4wb_caltech7_comvcnoad
+python train.py -c incviews5wb_caltech7_comvcnoad
+python train.py -c incviews6wb_caltech7_comvcnoad
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_caltech7_comvcnoad
+python train.py -c incviews3bw_caltech7_comvcnoad
+python train.py -c incviews4bw_caltech7_comvcnoad
+python train.py -c incviews5bw_caltech7_comvcnoad
+python train.py -c incviews6bw_caltech7_comvcnoad
+
+# SAEKM model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_caltech7_saekm
+python train.py -c incviews3wb_caltech7_saekm
+python train.py -c incviews4wb_caltech7_saekm
+python train.py -c incviews5wb_caltech7_saekm
+python train.py -c incviews6wb_caltech7_saekm
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_caltech7_saekm
+python train.py -c incviews3bw_caltech7_saekm
+python train.py -c incviews4bw_caltech7_saekm
+python train.py -c incviews5bw_caltech7_saekm
+python train.py -c incviews6bw_caltech7_saekm
+
+# CAEKM model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_caltech7_caekm
+python train.py -c incviews3wb_caltech7_caekm
+python train.py -c incviews4wb_caltech7_caekm
+python train.py -c incviews5wb_caltech7_caekm
+python train.py -c incviews6wb_caltech7_caekm
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_caltech7_caekm
+python train.py -c incviews3bw_caltech7_caekm
+python train.py -c incviews4bw_caltech7_caekm
+python train.py -c incviews5bw_caltech7_caekm
+python train.py -c incviews6bw_caltech7_caekm
+
+# SAE model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_caltech7_sae
+python train.py -c incviews3wb_caltech7_sae
+python train.py -c incviews4wb_caltech7_sae
+python train.py -c incviews5wb_caltech7_sae
+python train.py -c incviews6wb_caltech7_sae
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_caltech7_sae
+python train.py -c incviews3bw_caltech7_sae
+python train.py -c incviews4bw_caltech7_sae
+python train.py -c incviews5bw_caltech7_sae
+python train.py -c incviews6bw_caltech7_sae
+
+# CAE model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_caltech7_cae
+python train.py -c incviews3wb_caltech7_cae
+python train.py -c incviews4wb_caltech7_cae
+python train.py -c incviews5wb_caltech7_cae
+python train.py -c incviews6wb_caltech7_cae
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_caltech7_cae
+python train.py -c incviews3bw_caltech7_cae
+python train.py -c incviews4bw_caltech7_cae
+python train.py -c incviews5bw_caltech7_cae
+python train.py -c incviews6bw_caltech7_cae
+
+# Run experiments with increasing views for PatchedMNIST dataset
+# SiMVC model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_patchedmnist_simvc
+python train.py -c incviews3wb_patchedmnist_simvc
+python train.py -c incviews4wb_patchedmnist_simvc
+python train.py -c incviews5wb_patchedmnist_simvc
+python train.py -c incviews6wb_patchedmnist_simvc
+python train.py -c incviews7wb_patchedmnist_simvc
+python train.py -c incviews8wb_patchedmnist_simvc
+python train.py -c incviews9wb_patchedmnist_simvc
+python train.py -c incviews10wb_patchedmnist_simvc
+python train.py -c incviews11wb_patchedmnist_simvc
+python train.py -c incviews12wb_patchedmnist_simvc
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_patchedmnist_simvc
+python train.py -c incviews3bw_patchedmnist_simvc
+python train.py -c incviews4bw_patchedmnist_simvc
+python train.py -c incviews5bw_patchedmnist_simvc
+python train.py -c incviews6bw_patchedmnist_simvc
+python train.py -c incviews7bw_patchedmnist_simvc
+python train.py -c incviews8bw_patchedmnist_simvc
+python train.py -c incviews9bw_patchedmnist_simvc
+python train.py -c incviews10bw_patchedmnist_simvc
+python train.py -c incviews11bw_patchedmnist_simvc
+python train.py -c incviews12bw_patchedmnist_simvc
+
+# CoMVC model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_patchedmnist_comvc
+python train.py -c incviews3wb_patchedmnist_comvc
+python train.py -c incviews4wb_patchedmnist_comvc
+python train.py -c incviews5wb_patchedmnist_comvc
+python train.py -c incviews6wb_patchedmnist_comvc
+python train.py -c incviews7wb_patchedmnist_comvc
+python train.py -c incviews8wb_patchedmnist_comvc
+python train.py -c incviews9wb_patchedmnist_comvc
+python train.py -c incviews10wb_patchedmnist_comvc
+python train.py -c incviews11wb_patchedmnist_comvc
+python train.py -c incviews12wb_patchedmnist_comvc
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_patchedmnist_comvc
+python train.py -c incviews3bw_patchedmnist_comvc
+python train.py -c incviews4bw_patchedmnist_comvc
+python train.py -c incviews5bw_patchedmnist_comvc
+python train.py -c incviews6bw_patchedmnist_comvc
+python train.py -c incviews7bw_patchedmnist_comvc
+python train.py -c incviews8bw_patchedmnist_comvc
+python train.py -c incviews9bw_patchedmnist_comvc
+python train.py -c incviews10bw_patchedmnist_comvc
+python train.py -c incviews11bw_patchedmnist_comvc
+python train.py -c incviews12bw_patchedmnist_comvc
+
+# CoMVC without adaptive weight model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_patchedmnist_comvcnoad
+python train.py -c incviews3wb_patchedmnist_comvcnoad
+python train.py -c incviews4wb_patchedmnist_comvcnoad
+python train.py -c incviews5wb_patchedmnist_comvcnoad
+python train.py -c incviews6wb_patchedmnist_comvcnoad
+python train.py -c incviews7wb_patchedmnist_comvcnoad
+python train.py -c incviews8wb_patchedmnist_comvcnoad
+python train.py -c incviews9wb_patchedmnist_comvcnoad
+python train.py -c incviews10wb_patchedmnist_comvcnoad
+python train.py -c incviews11wb_patchedmnist_comvcnoad
+python train.py -c incviews12wb_patchedmnist_comvcnoad
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_patchedmnist_comvcnoad
+python train.py -c incviews3bw_patchedmnist_comvcnoad
+python train.py -c incviews4bw_patchedmnist_comvcnoad
+python train.py -c incviews5bw_patchedmnist_comvcnoad
+python train.py -c incviews6bw_patchedmnist_comvcnoad
+python train.py -c incviews7bw_patchedmnist_comvcnoad
+python train.py -c incviews8bw_patchedmnist_comvcnoad
+python train.py -c incviews9bw_patchedmnist_comvcnoad
+python train.py -c incviews10bw_patchedmnist_comvcnoad
+python train.py -c incviews11bw_patchedmnist_comvcnoad
+python train.py -c incviews12bw_patchedmnist_comvcnoad
+
+# SAEKM model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_patchedmnist_saekm
+python train.py -c incviews3wb_patchedmnist_saekm
+python train.py -c incviews4wb_patchedmnist_saekm
+python train.py -c incviews5wb_patchedmnist_saekm
+python train.py -c incviews6wb_patchedmnist_saekm
+python train.py -c incviews7wb_patchedmnist_saekm
+python train.py -c incviews8wb_patchedmnist_saekm
+python train.py -c incviews9wb_patchedmnist_saekm
+python train.py -c incviews10wb_patchedmnist_saekm
+python train.py -c incviews11wb_patchedmnist_saekm
+python train.py -c incviews12wb_patchedmnist_saekm
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_patchedmnist_saekm
+python train.py -c incviews3bw_patchedmnist_saekm
+python train.py -c incviews4bw_patchedmnist_saekm
+python train.py -c incviews5bw_patchedmnist_saekm
+python train.py -c incviews6bw_patchedmnist_saekm
+python train.py -c incviews7bw_patchedmnist_saekm
+python train.py -c incviews8bw_patchedmnist_saekm
+python train.py -c incviews9bw_patchedmnist_saekm
+python train.py -c incviews10bw_patchedmnist_saekm
+python train.py -c incviews11bw_patchedmnist_saekm
+python train.py -c incviews12bw_patchedmnist_saekm
+
+# CAEKM model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_patchedmnist_caekm
+python train.py -c incviews3wb_patchedmnist_caekm
+python train.py -c incviews4wb_patchedmnist_caekm
+python train.py -c incviews5wb_patchedmnist_caekm
+python train.py -c incviews6wb_patchedmnist_caekm
+python train.py -c incviews7wb_patchedmnist_caekm
+python train.py -c incviews8wb_patchedmnist_caekm
+python train.py -c incviews9wb_patchedmnist_caekm
+python train.py -c incviews10wb_patchedmnist_caekm
+python train.py -c incviews11wb_patchedmnist_caekm
+python train.py -c incviews12wb_patchedmnist_caekm
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_patchedmnist_caekm
+python train.py -c incviews3bw_patchedmnist_caekm
+python train.py -c incviews4bw_patchedmnist_caekm
+python train.py -c incviews5bw_patchedmnist_caekm
+python train.py -c incviews6bw_patchedmnist_caekm
+python train.py -c incviews7bw_patchedmnist_caekm
+python train.py -c incviews8bw_patchedmnist_caekm
+python train.py -c incviews9bw_patchedmnist_caekm
+python train.py -c incviews10bw_patchedmnist_caekm
+python train.py -c incviews11bw_patchedmnist_caekm
+python train.py -c incviews12bw_patchedmnist_caekm
+
+# SAE model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_patchedmnist_sae
+python train.py -c incviews3wb_patchedmnist_sae
+python train.py -c incviews4wb_patchedmnist_sae
+python train.py -c incviews5wb_patchedmnist_sae
+python train.py -c incviews6wb_patchedmnist_sae
+python train.py -c incviews7wb_patchedmnist_sae
+python train.py -c incviews8wb_patchedmnist_sae
+python train.py -c incviews9wb_patchedmnist_sae
+python train.py -c incviews10wb_patchedmnist_sae
+python train.py -c incviews11wb_patchedmnist_sae
+python train.py -c incviews12wb_patchedmnist_sae
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_patchedmnist_sae
+python train.py -c incviews3bw_patchedmnist_sae
+python train.py -c incviews4bw_patchedmnist_sae
+python train.py -c incviews5bw_patchedmnist_sae
+python train.py -c incviews6bw_patchedmnist_sae
+python train.py -c incviews7bw_patchedmnist_sae
+python train.py -c incviews8bw_patchedmnist_sae
+python train.py -c incviews9bw_patchedmnist_sae
+python train.py -c incviews10bw_patchedmnist_sae
+python train.py -c incviews11bw_patchedmnist_sae
+python train.py -c incviews12bw_patchedmnist_sae
+
+# CAE model
+# incviews2wb: increasing views from worst to best
+python train.py -c incviews2wb_patchedmnist_cae
+python train.py -c incviews3wb_patchedmnist_cae
+python train.py -c incviews4wb_patchedmnist_cae
+python train.py -c incviews5wb_patchedmnist_cae
+python train.py -c incviews6wb_patchedmnist_cae
+python train.py -c incviews7wb_patchedmnist_cae
+python train.py -c incviews8wb_patchedmnist_cae
+python train.py -c incviews9wb_patchedmnist_cae
+python train.py -c incviews10wb_patchedmnist_cae
+python train.py -c incviews11wb_patchedmnist_cae
+python train.py -c incviews12wb_patchedmnist_cae
+
+# incviews2bw: increasing views from best to worst
+python train.py -c incviews2bw_patchedmnist_cae
+python train.py -c incviews3bw_patchedmnist_cae
+python train.py -c incviews4bw_patchedmnist_cae
+python train.py -c incviews5bw_patchedmnist_cae
+python train.py -c incviews6bw_patchedmnist_cae
+python train.py -c incviews7bw_patchedmnist_cae
+python train.py -c incviews8bw_patchedmnist_cae
+python train.py -c incviews9bw_patchedmnist_cae
+python train.py -c incviews10bw_patchedmnist_cae
+python train.py -c incviews11bw_patchedmnist_cae
+python train.py -c incviews12bw_patchedmnist_cae


### PR DESCRIPTION
Add `scripts` folder under `src` and include shell scripts for running experiments and generating datasets.

* **Add `generate_datasets.sh`**: Generates datasets for the project.
* **Add `benchmark.sh`**: Runs benchmark experiments for various models across different datasets.
* **Add `ablation.sh`**: Runs ablation study experiments for fusion methods, MV-SSL methods, and SV-SSL methods on NoisyMNIST and Caltech7 datasets.
* **Add `increasing_views.sh`**: Runs experiments with increasing views for Caltech7 and PatchedMNIST datasets, including different models and view orders.
* **Update `README.md`**: Reflects the new location of `.sh` scripts and their annotations.

