### PR TITLE
Fix debug mode to work without input parameters

### DIFF
--- a/src/config/__init__.py
+++ b/src/config/__init__.py
@@ -14,7 +14,7 @@ SKIP_KEYS = ("illegal_vars",)
 
 def parse_config_name_arg():
     parser = ArgumentParser()
-    parser.add_argument("-c", "--config", dest="config_name", required=True)
+    parser.add_argument("-c", "--config", dest="config_name", required=False, default="default_config")
     return parser.parse_known_args()[0].config_name
 
 
@@ -59,8 +59,8 @@ def parse_cli_args(cfg_dict):
         parser.add_argument("--" + key, dest=key, type=value_type)
 
     args, unknown = parser.parse_known_args()
-    # The only unknown argument we expect to find is "-c" or "--config".
-    assert (len(unknown) == 2) and (unknown[0] in ("-c", "--config")), f"Got unexpected unknown arguments: {unknown}"
+    if len(unknown) > 0:
+        assert (len(unknown) == 2) and (unknown[0] in ("-c", "--config")), f"Got unexpected unknown arguments: {unknown}"
     args = vars(args)
     return args
 


### PR DESCRIPTION
Modify `parse_config_name_arg` and `parse_cli_args` functions in `src/config/__init__.py` to allow debugging without input parameters.

* **parse_config_name_arg**: Add a default value for the `config_name` argument, allowing it to be optional.
* **parse_cli_args**: Update to handle the case when no unknown arguments are provided, ensuring it only asserts when unknown arguments are present.

